### PR TITLE
Add globe arc timeout cleanup

### DIFF
--- a/src/components/Globe.tsx
+++ b/src/components/Globe.tsx
@@ -178,6 +178,7 @@ export const GlobeComponent = ({
   const globeRef = useRef<any>(null);
   const [currentRegion, setCurrentRegion] = useState<string | null>(null);
   const [hoveredRecipe, setHoveredRecipe] = useState<Recipe | null>(null);
+  const arcTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isGlobeLoaded, setIsGlobeLoaded] = useState(false);
   const [tooltip, setTooltip] = useState<TooltipData | null>(null);
   const [geoJsonData, setGeoJsonData] = useState<any>(null);
@@ -521,6 +522,46 @@ export const GlobeComponent = ({
     }, 50);
 
     return () => clearInterval(pulseInterval);
+  }, [selectedRecipe]);
+
+  // Display a temporary arc when a recipe is selected
+  useEffect(() => {
+    if (!globeRef.current || !selectedRecipe) return;
+
+    const [lat, lng] = selectedRecipe.coordinates;
+    const globe = globeRef.current;
+
+    const arc = [{
+      startLat: lat,
+      startLng: lng,
+      endLat: lat,
+      endLng: lng,
+      color: '#ff6b6b'
+    }];
+
+    globe.arcsData(arc)
+         .arcColor('color')
+         .arcAltitude(0.2)
+         .arcStroke(0.5)
+         .arcDashLength(0.4)
+         .arcDashGap(4)
+         .arcDashInitialGap(() => Math.random() * 4)
+         .arcDashAnimateTime(1000);
+
+    // Remove arc after a short delay
+    const timeoutId = setTimeout(() => {
+      globe.arcsData([]);
+    }, 2000);
+
+    arcTimeoutRef.current = timeoutId;
+
+    return () => {
+      if (arcTimeoutRef.current) {
+        clearTimeout(arcTimeoutRef.current);
+        arcTimeoutRef.current = null;
+      }
+      globe.arcsData([]);
+    };
   }, [selectedRecipe]);
 
   return (


### PR DESCRIPTION
## Summary
- show a temporary arc when a recipe is selected
- store the setTimeout id and clear it on unmount

## Testing
- `npm run build-no-errors` *(fails: vite not found / missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_684fa8ac837083278d58425236270c7a