### PR TITLE
Use env var for Spoonacular API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Spoonacular API key
+VITE_SPOONACULAR_KEY=your-api-key-here

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
+.env.*
+!.env.example
 
 # Editor directories and files
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -28,3 +28,14 @@ export default {
 - Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`
 - Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
 - Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
+
+## Environment Variables
+
+Create a `.env` file in the project root with the following variable:
+
+```
+VITE_SPOONACULAR_KEY=your-api-key-here
+```
+
+This key is used by the API service in `src/services/api.ts` to access the Spoonacular API.
+See `.env.example` for an example file.

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3,9 +3,9 @@
  * Documentation: https://spoonacular.com/food-api/docs
  */
 
-// NOTE: You'll need to replace this with your actual API key from Spoonacular
-// Get one from: https://spoonacular.com/food-api/console#Dashboard
-const API_KEY = '52a9dd1d347844378be7d8d835e2ed91';
+// Use the API key provided via Vite environment variables
+// Define VITE_SPOONACULAR_KEY in a `.env` file at the project root
+const API_KEY = import.meta.env.VITE_SPOONACULAR_KEY as string;
 const BASE_URL = 'https://api.spoonacular.com';
 
 // Common query params used with most endpoints


### PR DESCRIPTION
## Summary
- replace hardcoded `API_KEY` with `import.meta.env.VITE_SPOONACULAR_KEY`
- document API key setup in README and provide `.env.example`
- update `.gitignore` to keep `.env.example`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684fa8a1846c83279cdbc397fee8be46